### PR TITLE
Duplicated paths after addPrefix

### DIFF
--- a/ClassLoader.php
+++ b/ClassLoader.php
@@ -92,15 +92,15 @@ class ClassLoader
         }
         if (isset($this->prefixes[$prefix])) {
             if (is_array($paths)) {
-                $this->prefixes[$prefix] = array_merge(
+                $this->prefixes[$prefix] = array_unique(array_merge(
                     $this->prefixes[$prefix],
                     $paths
-                );
-            } if (!in_array($paths, $this->prefixes[$prefix])) {
+                ));
+            } else if (!in_array($paths, $this->prefixes[$prefix])) {
                  $this->prefixes[$prefix][] = $paths;
             }
         } else {
-            $this->prefixes[$prefix] = (array) $paths;
+            $this->prefixes[$prefix] = array_unique((array) $paths);
         }
     }
 

--- a/ClassLoader.php
+++ b/ClassLoader.php
@@ -91,10 +91,14 @@ class ClassLoader
             return;
         }
         if (isset($this->prefixes[$prefix])) {
-            $this->prefixes[$prefix] = array_merge(
-                $this->prefixes[$prefix],
-                (array) $paths
-            );
+            if (is_array($paths)) {
+                $this->prefixes[$prefix] = array_merge(
+                    $this->prefixes[$prefix],
+                    $paths
+                );
+            } if (!in_array($paths, $this->prefixes[$prefix])) {
+                 $this->prefixes[$prefix][] = $paths;
+            }
         } else {
             $this->prefixes[$prefix] = (array) $paths;
         }

--- a/Tests/ClassLoaderTest.php
+++ b/Tests/ClassLoaderTest.php
@@ -86,6 +86,16 @@ class ClassLoaderTest extends \PHPUnit_Framework_TestCase
         $this->assertCount(1, $prefixes['Foo']);
     }
 
+    public function testAddPrefixesSingle()
+    {
+        $loader = new ClassLoader();
+        $loader->addPrefixes(array('Foo' => array('foo', 'foo')));
+        $loader->addPrefixes(array('Foo' => array('foo')));
+        $prefixes = $loader->getPrefixes();
+        $this->assertArrayHasKey('Foo', $prefixes);
+        $this->assertCount(1, $prefixes['Foo'], print_r($prefixes, true));
+    }
+
     public function testAddPrefixMulti()
     {
         $loader = new ClassLoader();

--- a/Tests/ClassLoaderTest.php
+++ b/Tests/ClassLoaderTest.php
@@ -76,14 +76,26 @@ class ClassLoaderTest extends \PHPUnit_Framework_TestCase
         );
     }
 
-    public function testAddPrefix()
+    public function testAddPrefixSingle()
     {
         $loader = new ClassLoader();
         $loader->addPrefix('Foo', __DIR__.DIRECTORY_SEPARATOR.'Fixtures');
         $loader->addPrefix('Foo', __DIR__.DIRECTORY_SEPARATOR.'Fixtures');
         $prefixes = $loader->getPrefixes();
         $this->assertArrayHasKey('Foo', $prefixes);
+        $this->assertCount(1, $prefixes['Foo']);
+    }
+
+    public function testAddPrefixMulti()
+    {
+        $loader = new ClassLoader();
+        $loader->addPrefix('Foo', 'foo');
+        $loader->addPrefix('Foo', 'bar');
+        $prefixes = $loader->getPrefixes();
+        $this->assertArrayHasKey('Foo', $prefixes);
         $this->assertCount(2, $prefixes['Foo']);
+        $this->assertContains('foo', $prefixes['Foo']);
+        $this->assertContains('bar', $prefixes['Foo']);
     }
 
     public function testUseIncludePath()


### PR DESCRIPTION
Having UniversalClassLoader deprecated raise various issues... and ClassLoader doesn't provide the same features... :(

This one avoid duplication of paths for a given prefix, so can improve perf is such case.
